### PR TITLE
[CHANGED] Now function `domain` is called `domain_expr`

### DIFF
--- a/examples/simple_props.py
+++ b/examples/simple_props.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 
 from pypbt import domain
+from pypbt.domain import domain_expr
 from pypbt.quantifier import exists, forall
 
 
@@ -16,7 +17,7 @@ def prop_superstupid_2(x):
 
 
 @forall(xs= domain.List(domain.Int(), min_len= 4, max_len= 4))
-@forall(x= lambda xs: domain.domain(xs, is_exhaustible= True))
+@forall(x= lambda xs: domain_expr(xs, is_exhaustible= True))
 def prop_list_and_element_from_it(xs, x):
     return x in xs
 
@@ -43,12 +44,12 @@ def prop_la_suma_es_conmutativa(x, y):
 
 
 @forall(x= domain.Int())
-@exists(y= domain.domain(range(1, 9), is_exhaustible= True))
+@exists(y= domain_expr(range(1, 9), is_exhaustible= True))
 def prop_stupid(x, y):
     return x % y > 1
 
 
-@exists(x= domain.domain(range(10), is_exhaustible= True))
+@exists(x= domain_expr(range(10), is_exhaustible= True))
 def prop_even_more_stupid(x):
     return x > 7
 

--- a/src/pypbt/runner.py
+++ b/src/pypbt/runner.py
@@ -19,7 +19,7 @@ def run_props(file: Path) -> None:
         if is_qcproperty(obj):
             prop = obj
             print(prop)
-            for i, result in enumerate(prop(env= {}), 1):
+            for i, result in enumerate(prop(env= {}), start= 1):
                 if result:
                     print(".", end= "", flush= True)
                 else:

--- a/tests/test_quantifiers.py
+++ b/tests/test_quantifiers.py
@@ -26,7 +26,7 @@ def pred_false(x):
     ]
 )
 def test_finds_counterexample(iterable, pred):
-    dom = domain.domain(iterable, is_exhaustible= True)
+    dom = domain.domain_expr(iterable, is_exhaustible= True)
     prop = quantifier.forall(x= dom)(pred)
     assert not all(result for _, result in zip(range(100), prop.qcproperty(env= {})))
     


### PR DESCRIPTION
[CHANGED] Now function `domain` is called `domain_expr`
  
    This way it no longer has the same name as the module `domain`

[ADDED] More options for syntax sugar in domain_expr

    - Added generator functions and singleton domains.
    - There is still room for some additions. See TODO in code.

